### PR TITLE
Cli interface

### DIFF
--- a/bin/dynamodb-exporter
+++ b/bin/dynamodb-exporter
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+$: << File.absolute_path('lib')
+
+require 'dynamodb/exporter/app'
+
+Dynamodb::Exporter::App.start

--- a/dynamodb-exporter.gemspec
+++ b/dynamodb-exporter.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
 
   spec.add_runtime_dependency "aws-sdk"
+  spec.add_runtime_dependency "thor"
 end

--- a/lib/dynamodb/exporter/app.rb
+++ b/lib/dynamodb/exporter/app.rb
@@ -1,5 +1,6 @@
 require 'thor'
 require 'dynamodb/exporter/export'
+require 'json'
 
 module Dynamodb
   module Exporter
@@ -17,7 +18,9 @@ module Dynamodb
         say 'Begining export...', :white
 
         contents = Export.new(table_name, options[:read_ratio]).run!
-        File.open(options[:output]).write(contents)
+        File.open(options[:output], 'w') do |file|
+          file.write(JSON::generate(contents))
+        end
 
         say 'Export complete', :green
       end

--- a/lib/dynamodb/exporter/app.rb
+++ b/lib/dynamodb/exporter/app.rb
@@ -1,0 +1,27 @@
+require 'thor'
+require 'dynamodb/exporter/export'
+
+module Dynamodb
+  module Exporter
+    class App < Thor
+
+      include Thor::Actions
+      package_name 'Dynamodb Exporter'
+
+      desc 'export [table_name]', 'Exports the contents of the given table to a json dump'
+      method_option :read_ratio, :type => :numeric, :desc => 'The percentage of read capacity to use (out of 100)', :default => '10'
+      method_option :region, :type => :string, :desc => 'The region to use, default will be picked up from ENV variables'
+      method_option :limit, :type => :numeric, :desc => 'How many results to get per request', :default => 20
+      method_option :output, :type => :string, :desc => 'Where the contents should be output', :default => './output.json'
+      def export(table_name)
+        say 'Begining export...', :white
+
+        contents = Export.new(table_name, options[:read_ratio]).run!
+        File.open(options[:output]).write(contents)
+
+        say 'Export complete', :green
+      end
+
+    end
+  end
+end

--- a/lib/dynamodb/exporter/export.rb
+++ b/lib/dynamodb/exporter/export.rb
@@ -5,60 +5,69 @@ module Dynamodb
   module Exporter
     class Export
 
-      attr_reader :table_name, :contents, :rate
+      attr_reader :table_name, :rate, :items_read, :consumed_capacity
 
-      def initialize(table_name, rate)
-        @table_name = table_name
-        @rate       = rate
-        @ddb        = ::AWS::DynamoDB::Client.new(:api_version => '2011-12-05')
+      def initialize(table_name, rate, io_stream)
+        @table_name      = table_name
+        @rate            = rate
+        @ddb             = ::AWS::DynamoDB::Client.new(:api_version => '2012-08-10')
 
-        @contents   = []
-        @start_key  = true
+        @io_stream       = io_stream
+        @items_read      = 0
+        @mutex           = Mutex.new
+        @threads_complete = 0
+        @consumed_capacity = 0
       end
 
       def run!
-        while @start_key do
-          scan.tap do |s|
-            @contents << contents_from(s)
-            @start_key = last_key_from s
+        Thread.new do
+          total_segments = 8
+          threads = []
+
+          total_segments.times do |segment|
+            threads << Thread.new do
+              t[:start_key] = true
+
+              while t[:start_key] do
+                @ddb.scan(options_with(t[:start_key], total_segments, segment)).tap do |s|
+                  @mutex.synchronize do
+                    @consumed_capacity = s[:consumed_capacity][:capacity_units]
+                    @io_stream.tap do |io|
+                      s[:member].each { |m| io << "#{JSON::generate(m)}\n" }
+                    end.flush
+                    @items_read = items_read + s[:member].length
+                  end
+                  t[:start_key] = s[:last_evaluated_key]
+                end
+              end
+            end
           end
 
-          sleep 1
+          threads.each { |t| t.join }
         end
-
-        @contents
       end
 
-      def write
-        File.open('out.yaml', 'w') {|f| f.write @contents.to_yaml }
+      def percentage_done
+        ((items_read.to_f / item_count.to_f) * 100).round
+      end
+
+      def item_count
+        @item_count ||= @ddb.describe_table({:table_name => @table_name})[:table][:item_count]
       end
 
       protected
 
-      def read_capacity
-        table_meta["Table"]["ProvisionedThroughput"]["ReadCapacityUnits"]
+      def t
+        Thread.current
       end
 
-      def table_meta
-        @table_meta ||= @ddb.describe_table( :table_name => table_name )
-      end
-
-      def scan
-        @ddb.scan options_with @start_key
-      end
-
-      def last_key_from(scan)
-        scan["LastEvaluatedKey"]
-      end
-
-      def contents_from(scan)
-        scan["Items"]
-      end
-
-      def options_with(start_key = nil)
+      def options_with(start_key = nil, total_segments = 1, segment = 0)
         {
-          :table_name => table_name,
-          :limit => rate.to_i,
+          :total_segments           => total_segments,
+          :table_name               => table_name,
+          :limit                    => rate.to_i,
+          :segment                  => segment,
+          :return_consumed_capacity => 'TOTAL'
         }.tap do |o|
           o[:exclusive_start_key] = start_key if start_key.is_a? Hash
         end

--- a/lib/dynamodb/exporter/export.rb
+++ b/lib/dynamodb/exporter/export.rb
@@ -44,7 +44,7 @@ module Dynamodb
       end
 
       def scan
-        @ddb.scan options_with(limit, @start_key)
+        @ddb.scan options_with @start_key
       end
 
       def last_key_from(scan)
@@ -55,10 +55,10 @@ module Dynamodb
         scan["Items"]
       end
 
-      def options_with(limit, start_key = nil)
+      def options_with(start_key = nil)
         {
           :table_name => table_name,
-          :limit => rate,
+          :limit => rate.to_i,
         }.tap do |o|
           o[:exclusive_start_key] = start_key if start_key.is_a? Hash
         end


### PR DESCRIPTION
Adds CLI interface to exporter.
## Usage

``` bash
dynamodb-exporter my-table-i-want-to-export --read-ratio=100 --output=/tmp/my-json-dump.json --limit=100
```
